### PR TITLE
Update APIs and fix unit tests

### DIFF
--- a/server/app/blocks_test.go
+++ b/server/app/blocks_test.go
@@ -115,7 +115,7 @@ func TestUndeleteBlock(t *testing.T) {
 		th.Store.EXPECT().GetBlock(gomock.Eq("block-id")).Return(&block, nil)
 		th.Store.EXPECT().GetBoard(boardID).Return(board, nil)
 		th.Store.EXPECT().GetMembersForBoard(boardID).Return([]*model.BoardMember{}, nil)
-		err := th.App.UndeleteBlock("block-id", "user-id-1")
+		_, err := th.App.UndeleteBlock("block-id", "user-id-1")
 		require.NoError(t, err)
 	})
 
@@ -129,7 +129,7 @@ func TestUndeleteBlock(t *testing.T) {
 		).Return([]model.Block{block}, nil)
 		th.Store.EXPECT().UndeleteBlock(gomock.Eq("block-id"), gomock.Eq("user-id-1")).Return(blockError{"error"})
 		th.Store.EXPECT().GetBlock(gomock.Eq("block-id")).Return(&block, nil)
-		err := th.App.UndeleteBlock("block-id", "user-id-1")
+		_, err := th.App.UndeleteBlock("block-id", "user-id-1")
 		require.Error(t, err, "error")
 	})
 }

--- a/server/integrationtests/permissions_test.go
+++ b/server/integrationtests/permissions_test.go
@@ -262,6 +262,8 @@ func TestPermissionsGetTeamTemplates(t *testing.T) {
 	testData := setupData(t, th)
 	clients := setupClients(th)
 
+	builtInTemplateCount := 7
+
 	ttCases := []TestCase{
 		// Get Team Boards
 		{"/teams/test-team/templates", methodGet, "", userAnon, http.StatusUnauthorized, 0},
@@ -271,13 +273,14 @@ func TestPermissionsGetTeamTemplates(t *testing.T) {
 		{"/teams/test-team/templates", methodGet, "", userCommenter, http.StatusOK, 2},
 		{"/teams/test-team/templates", methodGet, "", userEditor, http.StatusOK, 2},
 		{"/teams/test-team/templates", methodGet, "", userAdmin, http.StatusOK, 2},
+		// Built-in templates
 		{"/teams/0/templates", methodGet, "", userAnon, http.StatusUnauthorized, 0},
-		{"/teams/0/templates", methodGet, "", userNoTeamMember, http.StatusOK, 7},
-		{"/teams/0/templates", methodGet, "", userTeamMember, http.StatusOK, 7},
-		{"/teams/0/templates", methodGet, "", userViewer, http.StatusOK, 7},
-		{"/teams/0/templates", methodGet, "", userCommenter, http.StatusOK, 7},
-		{"/teams/0/templates", methodGet, "", userEditor, http.StatusOK, 7},
-		{"/teams/0/templates", methodGet, "", userAdmin, http.StatusOK, 7},
+		{"/teams/0/templates", methodGet, "", userNoTeamMember, http.StatusOK, builtInTemplateCount},
+		{"/teams/0/templates", methodGet, "", userTeamMember, http.StatusOK, builtInTemplateCount},
+		{"/teams/0/templates", methodGet, "", userViewer, http.StatusOK, builtInTemplateCount},
+		{"/teams/0/templates", methodGet, "", userCommenter, http.StatusOK, builtInTemplateCount},
+		{"/teams/0/templates", methodGet, "", userEditor, http.StatusOK, builtInTemplateCount},
+		{"/teams/0/templates", methodGet, "", userAdmin, http.StatusOK, builtInTemplateCount},
 	}
 	runTestCases(t, ttCases, testData, clients)
 }
@@ -454,7 +457,7 @@ func TestPermissionsDuplicateBoard(t *testing.T) {
 
 		{"/boards/{PUBLIC_BOARD_ID}/duplicate", methodPost, "", userAnon, http.StatusUnauthorized, 0},
 		{"/boards/{PUBLIC_BOARD_ID}/duplicate", methodPost, "", userNoTeamMember, http.StatusForbidden, 0},
-		{"/boards/{PUBLIC_BOARD_ID}/duplicate", methodPost, "", userTeamMember, http.StatusOK, 1}, // TODO: Confirm that this behavior is what we want
+		{"/boards/{PUBLIC_BOARD_ID}/duplicate", methodPost, "", userTeamMember, http.StatusForbidden, 0},
 		{"/boards/{PUBLIC_BOARD_ID}/duplicate", methodPost, "", userViewer, http.StatusOK, 1},
 		{"/boards/{PUBLIC_BOARD_ID}/duplicate", methodPost, "", userCommenter, http.StatusOK, 1},
 		{"/boards/{PUBLIC_BOARD_ID}/duplicate", methodPost, "", userEditor, http.StatusOK, 1},
@@ -490,7 +493,7 @@ func TestPermissionsDuplicateBoard(t *testing.T) {
 
 		{"/boards/{PUBLIC_BOARD_ID}/duplicate?toTeam=other-team", methodPost, "", userAnon, http.StatusUnauthorized, 0},
 		{"/boards/{PUBLIC_BOARD_ID}/duplicate?toTeam=other-team", methodPost, "", userNoTeamMember, http.StatusForbidden, 0},
-		{"/boards/{PUBLIC_BOARD_ID}/duplicate?toTeam=other-team", methodPost, "", userTeamMember, http.StatusOK, 1}, // TODO: Confirm that this behavior is what we want
+		{"/boards/{PUBLIC_BOARD_ID}/duplicate?toTeam=other-team", methodPost, "", userTeamMember, http.StatusForbidden, 0},
 		{"/boards/{PUBLIC_BOARD_ID}/duplicate?toTeam=other-team", methodPost, "", userViewer, http.StatusOK, 1},
 		{"/boards/{PUBLIC_BOARD_ID}/duplicate?toTeam=other-team", methodPost, "", userCommenter, http.StatusOK, 1},
 		{"/boards/{PUBLIC_BOARD_ID}/duplicate?toTeam=other-team", methodPost, "", userEditor, http.StatusOK, 1},
@@ -1101,7 +1104,7 @@ func TestPermissionsDeleteBoardMember(t *testing.T) {
 		{"/boards/{PUBLIC_TEMPLATE_ID}/members/team-member", methodDelete, "", userAdmin, http.StatusOK, 0},
 
 		// Invalid boardID
-		{"/boards/invalid/members/viewer", methodDelete, "", userAdmin, http.StatusForbidden, 0},
+		{"/boards/invalid/members/viewer", methodDelete, "", userAdmin, http.StatusNotFound, 0},
 
 		// Invalid memberID
 		{"/boards/{PUBLIC_TEMPLATE_ID}/members/invalid", methodDelete, "", userAdmin, http.StatusOK, 0},

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -494,7 +494,7 @@ func initTelemetry(opts telemetryOptions) *telemetry.Service {
 }
 
 func initNotificationService(backends []notify.Backend, logger *mlog.Logger) (*notify.Service, error) {
-	loggerBackend := notifylogger.New(logger, mlog.LvlDebug)
+	loggerBackend := notifylogger.New(logger, mlog.LvlTrace)
 
 	backends = append(backends, loggerBackend)
 

--- a/server/services/store/storetests/boards.go
+++ b/server/services/store/storetests/boards.go
@@ -120,7 +120,7 @@ func testGetBoardsForUserAndTeam(t *testing.T, store store.Store) {
 			TeamID: teamID1,
 			Type:   model.BoardTypeOpen,
 		}
-		_, _, err := store.InsertBoardWithAdmin(board1, userID)
+		rBoard1, _, err := store.InsertBoardWithAdmin(board1, userID)
 		require.NoError(t, err)
 
 		board2 := &model.Board{
@@ -128,7 +128,7 @@ func testGetBoardsForUserAndTeam(t *testing.T, store store.Store) {
 			TeamID: teamID1,
 			Type:   model.BoardTypePrivate,
 		}
-		_, _, err = store.InsertBoardWithAdmin(board2, userID)
+		rBoard2, _, err := store.InsertBoardWithAdmin(board2, userID)
 		require.NoError(t, err)
 
 		board3 := &model.Board{
@@ -136,7 +136,7 @@ func testGetBoardsForUserAndTeam(t *testing.T, store store.Store) {
 			TeamID: teamID1,
 			Type:   model.BoardTypeOpen,
 		}
-		_, err = store.InsertBoard(board3, "other-user")
+		rBoard3, err := store.InsertBoard(board3, "other-user")
 		require.NoError(t, err)
 
 		board4 := &model.Board{
@@ -164,16 +164,14 @@ func testGetBoardsForUserAndTeam(t *testing.T, store store.Store) {
 		_, err = store.InsertBoard(board6, "other-user")
 		require.NoError(t, err)
 
-		t.Run("should only find the two boards that the user is a member of for team 1", func(t *testing.T) {
+		t.Run("should only find the two boards that the user is a member of for team 1 plus the one open board", func(t *testing.T) {
 			boards, err := store.GetBoardsForUserAndTeam(userID, teamID1)
 			require.NoError(t, err)
-			require.Len(t, boards, 2)
-
-			boardIDs := []string{}
-			for _, board := range boards {
-				boardIDs = append(boardIDs, board.ID)
-			}
-			require.ElementsMatch(t, []string{board1.ID, board2.ID}, boardIDs)
+			require.ElementsMatch(t, []*model.Board{
+				rBoard1,
+				rBoard2,
+				rBoard3,
+			}, boards)
 		})
 
 		t.Run("should only find the board that the user is a member of for team 2", func(t *testing.T) {

--- a/server/swagger/swagger.yml
+++ b/server/swagger/swagger.yml
@@ -260,6 +260,32 @@ definitions:
     - schemeViewer
     type: object
     x-go-package: github.com/mattermost/focalboard/server/model
+  BoardMemberHistoryEntry:
+    description: BoardMemberHistoryEntry stores the information of the membership of a user on a board
+    properties:
+      action:
+        description: The action that added this history entry (created or deleted)
+        type: string
+        x-go-name: Action
+      boardId:
+        description: The ID of the board
+        type: string
+        x-go-name: BoardID
+      insertAt:
+        description: The insertion time
+        format: int64
+        type: integer
+        x-go-name: InsertAt
+      userId:
+        description: The ID of the user
+        type: string
+        x-go-name: UserID
+    required:
+    - boardId
+    - userId
+    - insertAt
+    type: object
+    x-go-package: github.com/mattermost/focalboard/server/model
   BoardMetadata:
     description: BoardMetadata contains metadata for a Board
     properties:
@@ -882,6 +908,8 @@ paths:
       responses:
         "200":
           description: success
+        "404":
+          description: board not found
         default:
           description: internal error
           schema:
@@ -904,6 +932,8 @@ paths:
           description: success
           schema:
             $ref: '#/definitions/Board'
+        "404":
+          description: board not found
         default:
           description: internal error
           schema:
@@ -932,6 +962,8 @@ paths:
           description: success
           schema:
             $ref: '#/definitions/Board'
+        "404":
+          description: board not found
         default:
           description: internal error
           schema:
@@ -959,34 +991,6 @@ paths:
       security:
       - BearerAuth: []
       summary: Exports an archive of all blocks for one boards.
-  /api/v1/boards/{boardID}/archive/import:
-    post:
-      consumes:
-      - multipart/form-data
-      operationId: archiveImport
-      parameters:
-      - description: Workspace ID
-        in: path
-        name: boardID
-        required: true
-        type: string
-      - description: archive file to import
-        in: formData
-        name: file
-        required: true
-        type: file
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-      summary: Import an archive of boards.
   /api/v1/boards/{boardID}/blocks:
     get:
       description: Returns blocks
@@ -1014,6 +1018,8 @@ paths:
             items:
               $ref: '#/definitions/Block'
             type: array
+        "404":
+          description: board not found
         default:
           description: internal error
           schema:
@@ -1102,6 +1108,8 @@ paths:
       responses:
         "200":
           description: success
+        "404":
+          description: block not found
         default:
           description: internal error
           schema:
@@ -1133,6 +1141,8 @@ paths:
       responses:
         "200":
           description: success
+        "404":
+          description: block not found
         default:
           description: internal error
           schema:
@@ -1163,6 +1173,8 @@ paths:
             items:
               $ref: '#/definitions/Block'
             type: array
+        "404":
+          description: board or block not found
         default:
           description: internal error
           schema:
@@ -1199,6 +1211,36 @@ paths:
             items:
               $ref: '#/definitions/Block'
             type: array
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/boards/{boardID}/blocks/{blockID}/undelete:
+    post:
+      description: Undeletes a block
+      operationId: undeleteBlock
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      - description: ID of block to undelete
+        in: path
+        name: blockID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/BlockPatch'
+        "404":
+          description: block not found
         default:
           description: internal error
           schema:
@@ -1276,6 +1318,8 @@ paths:
           description: success
           schema:
             $ref: '#/definitions/BoardsAndBlocks'
+        "404":
+          description: board not found
         default:
           description: internal error
           schema:
@@ -1327,6 +1371,8 @@ paths:
       responses:
         "200":
           description: success
+        "404":
+          description: board not found
         default:
           description: internal error
           schema:
@@ -1377,6 +1423,8 @@ paths:
           description: success
           schema:
             $ref: '#/definitions/Sharing'
+        "404":
+          description: board not found
         default:
           description: internal error
           schema:
@@ -1633,6 +1681,34 @@ paths:
       security:
       - BearerAuth: []
       summary: Exports an archive of all blocks for all the boards in a team.
+  /api/v1/teams/{teamID}/archive/import:
+    post:
+      consumes:
+      - multipart/form-data
+      operationId: archiveImport
+      parameters:
+      - description: Team ID
+        in: path
+        name: teamID
+        required: true
+        type: string
+      - description: archive file to import
+        in: formData
+        name: file
+        required: true
+        type: file
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Import an archive of boards.
   /api/v1/teams/{teamID}/boards:
     get:
       description: Returns team boards
@@ -1686,6 +1762,8 @@ paths:
           description: success
           schema:
             $ref: '#/definitions/FileUploadResponse'
+        "404":
+          description: board not found
         default:
           description: internal error
           schema:
@@ -1697,11 +1775,6 @@ paths:
       description: Returns the boards that match with a search term
       operationId: searchBoards
       parameters:
-      - description: Board ID
-        in: path
-        name: boardID
-        required: true
-        type: string
       - description: Team ID
         in: path
         name: teamID
@@ -1919,66 +1992,6 @@ paths:
             $ref: '#/definitions/ErrorResponse'
       security:
       - BearerAuth: []
-  /api/v1/workspaces/{workspaceID}/blocks/{blockID}/undelete:
-    post:
-      description: Undeletes a block
-      operationId: undeleteBlock
-      parameters:
-      - description: Workspace ID
-        in: path
-        name: workspaceID
-        required: true
-        type: string
-      - description: ID of block to undelete
-        in: path
-        name: blockID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /boards/{boardID}/{rootID}/{fileID}:
-    get:
-      description: Returns the contents of an uploaded file
-      operationId: getFile
-      parameters:
-      - description: Board ID
-        in: path
-        name: boardID
-        required: true
-        type: string
-      - description: ID of the root block
-        in: path
-        name: rootID
-        required: true
-        type: string
-      - description: ID of the file
-        in: path
-        name: fileID
-        required: true
-        type: string
-      produces:
-      - application/json
-      - image/jpg
-      - image/png
-      - image/gif
-      responses:
-        "200":
-          description: success
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
   /boards/{boardID}/join:
     post:
       description: Become a member of a board
@@ -1996,10 +2009,35 @@ paths:
           description: success
           schema:
             $ref: '#/definitions/BoardMember'
+        "403":
+          description: access denied
         "404":
           description: board not found
-        "503":
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /boards/{boardID}/leave:
+    post:
+      description: Remove your own membership from a board
+      operationId: leaveBoard
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        "403":
           description: access denied
+        "404":
+          description: board not found
         default:
           description: internal error
           schema:
@@ -2029,6 +2067,8 @@ paths:
           description: success
           schema:
             $ref: '#/definitions/BoardMember'
+        "404":
+          description: board not found
         default:
           description: internal error
           schema:


### PR DESCRIPTION
Ok, I've reviewed the changes and fixed the broken unit tests. Overall, this is awesome and exactly what we need. A few followups:
* I updated duplicateBoard to succeed for public templates (like getBlocks)
  * So it will fail for public, non-template boards
  * Duplicating a board implicitly gains access to its contents, so should be similar to getBlocks
  * We should consider refactoring how public templates are handled. Perhaps with a separate set of template-specific APIs?
* I updated deleteBoard, addMember, and deleteMember to return 404 not found if the boardID is invalid
  * I think this is better than 403 (forbidden), but we can discuss the pros and cons.
  * Pros: Easier for client to handle
  * Cons: Slight perf overhead, and disclosing extra info (existence of board)

Feel free to update and merge as appropriate. LMK if you have any questions or concerns. Thanks!